### PR TITLE
Actually use Oracle JDBC driver + Elasticsearch clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <lombok.version>1.18.22</lombok.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.platform.version>3.0.0.Alpha4</quarkus.platform.version>
+        <quarkus.platform.version>3.0.0.Alpha5</quarkus.platform.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/org/test/jdbcoracle/config/TestOracleJDBCConfig.java
+++ b/src/main/java/org/test/jdbcoracle/config/TestOracleJDBCConfig.java
@@ -1,8 +1,47 @@
 package org.test.jdbcoracle.config;
 
+import java.io.IOException;
+import java.util.Map;
+
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RestClient;
+import org.test.jdbcoracle.repository.TestEntityRepository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.quarkus.runtime.StartupEvent;
 
 @ApplicationScoped
 public class TestOracleJDBCConfig {
+
+	@Inject
+	TestEntityRepository repository;
+
+	@Inject
+	RestClient restClient;
+
+	@Inject
+	ElasticsearchClient client;
+
+	void onStart(@Observes StartupEvent ev) {
+		this.repository.findAll();
+		try {
+			this.restClient.performRequest( new Request( "", "" ) );
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+		try {
+			this.client.search( b -> b.q( "foo" ), Map.class );
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
 }


### PR DESCRIPTION
Otherwise we can't reproduce the problem.

Also, upgrade to the latest Quarkus 3.0 (still affected).